### PR TITLE
Update plotLoadings() annotation labels

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -111,13 +111,13 @@ plotLoadings <- function(object, term, n_genes = 10) {
     Wabs <- abs(W) * abs(Z)
     gene_index <- order(Wabs, decreasing = TRUE)[1:n_genes]
 
-    anno <- rep("in geneset", length(Z))
+    anno <- rep("in geneset", length(gene_index))
     anno[Zchanged[gene_index] == 1] <- "gained"
 
     df <- data.frame(
         gene = gene_labels[gene_index],
         absolute_weight = Wabs[gene_index],
-        Annotation = anno[gene_index]
+        Annotation = anno
     )
     df[["gene"]] <- factor(df[["gene"]],
                            levels = rev(df[["gene"]]))


### PR DESCRIPTION
Hi,

This pull request fixes a strange behaviour of `plotLoadings()`, although not entirely. 

Briefly, I was trying to plot the loadings of genes of a term. By increasing the `n_genes` value from 10 to 30, I saw that the `'Annotation'` labels of some of the genes changed. When I tried to check which were the genes that are present in the geneset term, as opposed to those which were gained by the model, as explained in the [vignette of `slalom`](https://www.bioconductor.org/packages/release/bioc/vignettes/slalom/inst/doc/vignette.html) (please check section 6.1), I found that many genes that were annotated as `'gained'` were actually present in the term, and vice versa.

When I checked the source code (code at [lines 114 to 115 in plotting.R](https://github.com/PMBio/Rslalom/blob/master/R/plotting.R#L114-L115)), I realised that `anno` has the same length as the number of genes in the `slalom` model, whereas the` 'gained'` label is indexed to the genes selected by `n_genes`, hence the mislabelling of the genes. 

```R
> length(anno)
[1] 506
> length(model$geneNames)
[1] 506
> length(Zchanged[gene_index])
[1] 30
```

The example below shows that for `n_genes = 10`, the first and third genes are labeled as `'gained'` although both are already present in the geneset term. Also, genes 6 and 7 are labeled as `'in geneset'`, although they are not. 

```R
# For n_genes = 10
# Index genes labeled as 'gained'
> which(df$gene %in% df$gene[df$Annotation == "gained"])
[1] 1 2 3
# Index genes labeled as 'in geneset'
> which(df$gene %in% df$gene[df$Annotation == "in geneset"])
[1]  4  5  6  7  8  9 10
# Index genes present in geneset
> which(df$gene %in% genesets[[geneset_term]]@geneIds)
[1]  1  3  5  8  9 10
```

If we now increase the `n_genes` value to 30, the second gene which was previously labeled as `'gained'` is now labeled as `'in geneset'`, although it is not present in the geneset. 

```R
# For n_genes = 30
# Index genes labeled as 'gained'
> which(df$gene %in% df$gene[df$Annotation == "gained"])
[1]  1  3 14 16 19 23
# Index genes labeled as 'in geneset'
> which(df$gene %in% df$gene[df$Annotation == "in geneset"])
 [1]  2  4  5  6  7  8  9 10 11 12 13 15 17 18 20 21 22 24 25 26 27 28 29 30
# Index genes present in geneset
> which(df$gene %in% genesets[[geneset_term]]@geneIds)
 [1]  1  3  5  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
```

This fix, however, does not solve all the issues related to the labelling of the genes. Assuming that `df2` is the output data frame of the proposed fix, we can now see that for the top 29 genes, the labelling follows what is expected. However, gene number 30 is labeled as being `'in geneset'`, although it is actually not. 

```R
# For n_genes = 30
# Index genes labeled as 'gained'
> which(df2$gene %in% df2$gene[df2$Annotation == "gained"])
[1] 2 4 6 7
# Index genes labeled as 'in geneset'
> which(df2$gene %in% df2$gene[df2$Annotation == "in geneset"])
 [1]  1  3  5  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
# Index genes present in geneset
> which(df2$gene %in% genesets[[geneset_term]]@geneIds)
 [1]  1  3  5  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
```

This behaviour is related to how the labelling of the genes is being performed (please check the same code lines referenced above). If we check the `Zchanged` value for this gene, we can see that it is 0, hence its label as `'in geneset'`. Also, its `absolute_weight` is very close to 0. 

```R
> Zchanged[gene_index][30]
[1] 0
> df2[30, ]
      gene absolute_weight Annotation
30 Cacna1a    3.352052e-07 in geneset  
```

I guess that the labelling of the genes should be updated in such a way that two additional labels be included, each indicating whether the gene is present in or absent from the geneset, and that this gene is not relevant for the term, as its absolute weight is close to 0. This being said, I haven't found a decent way to do it. 

I hope my explanations and my examples were clear!

Best,
Leon